### PR TITLE
13b has 2 stanzas

### DIFF
--- a/hobbit.tsv
+++ b/hobbit.tsv
@@ -13,7 +13,7 @@ Number	First line	Reference (tentative)	Lines by Stanza	Notes
 11	Alive without breath,	05.046	4	Gollum riddle
 12	This thing all things devours:	05.055	6	Gollum riddle
 13	Fifteen birds in five fir-trees,	06.074	6	goblins
-13b	Burn, burn tree and fern!	06.077	15	continuation of goblin song
+13b	Burn, burn tree and fern!	06.077-06.078	4+11	continuation of goblin song
 14	The wind was on the withered heath,	07.098-07.103	4+4+4+4+4+4	dwarves (extract)
 15	Old fat spider spinning in a tree!	08.096-08.097	5+5	Bilbo
 16	Lazy Lob and crazy Cob	08.100-08.101	4+4	Bilbo (clearly identified as a new song)


### PR DESCRIPTION
13b. The continuation has 2 stanzas. It becomes evident if you look to an edition without the 1995 reset typeset like The Annotated Hobbit (2nd ed. p. 152), the Pocket Edition (p. 120) or the 1st Edition (p. 112).


![IMG_20201227_231537__01](https://user-images.githubusercontent.com/76666396/103180913-040ca380-489b-11eb-8a50-1a20f507b8c4.jpg)